### PR TITLE
Add MoondreamService with comprehensive vision-language capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,35 @@ curl -X POST -H "Content-Type: application/json" \
     http://localhost:8081/
 ```
 
+### 🌙 MoondreamService (Template)
+Vision-language model using Moondream2 for captioning, visual querying, object detection, and pointing.
+
+**Endpoints:**
+- `POST /caption` - Generate image captions
+- `POST /query` - Answer questions about images  
+- `POST /detect` - Detect specific objects in images
+- `POST /point` - Point to object locations in images
+
+```bash
+# Caption generation
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png",
+         "length": "normal"}' \
+    http://localhost:8002/caption
+
+# Visual querying
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png",
+         "question": "What food is shown in this image?"}' \
+    http://localhost:8002/query
+
+# Object detection
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png",
+         "object": "food"}' \
+    http://localhost:8002/detect
+```
+
 ## Quick Start
 
 ### Prerequisites
@@ -79,6 +108,7 @@ make docker-build
 docker build -t your-registry/clip-service:latest ./clip-service
 docker build -t your-registry/gemma-service:latest ./gemma-service
 docker build -t your-registry/grounding-dino-service:latest ./grounding-dino-service
+docker build -t your-registry/moondream-service:latest ./moondream-service
 ```
 
 ### 3. Deploy to Kubernetes
@@ -97,6 +127,11 @@ docker build -t your-registry/grounding-dino-service:latest ./grounding-dino-ser
 ./scripts/deploy_ray_service.sh gemma \
   --username bob \
   --node-selector gpu=true
+
+# Deploy Moondream service
+./scripts/deploy_ray_service.sh moondream \
+  --username charlie \
+  --node-selector gpu=true
 ```
 
 ### 4. Access Services
@@ -105,6 +140,7 @@ docker build -t your-registry/grounding-dino-service:latest ./grounding-dino-ser
 kubectl port-forward svc/alice-clip-service 8080:80
 kubectl port-forward svc/bob-gemma-service 8081:80
 kubectl port-forward svc/grounding-dino-service 8082:80
+kubectl port-forward svc/charlie-moondream-service 8083:80
 
 # Test CLIP service
 curl -X POST -H "Content-Type: application/json" \
@@ -149,6 +185,7 @@ make test-k8s
 # Run specific service tests
 pytest clip-service/tests/test_clip_service.py -v
 pytest tests/test_grounding_dino_service.py -v
+pytest moondream-service/tests/test_moondream_service.py -v
 
 # Run CLIP tests only
 make test-clip
@@ -186,6 +223,9 @@ ray-serve-inference-menagerie/
 ├── grounding-dino-service/ # Production object detection
 │   ├── app.py
 │   └── Dockerfile
+├── moondream-service/      # Moondream2 vision-language model
+│   ├── app.py
+│   └── Dockerfile
 ├── k8s-manifests/          # Kubernetes deployments
 │   ├── *-deployment.yaml  # Service deployments
 │   ├── *-service.yaml     # Service definitions
@@ -208,6 +248,7 @@ ray-serve-inference-menagerie/
 - `CLIP_SERVICE_URL` - CLIP service endpoint (default: http://localhost:8000)
 - `GEMMA_SERVICE_URL` - Gemma service endpoint (default: http://localhost:8001)  
 - `GROUNDING_DINO_SERVICE_URL` - Grounding DINO endpoint (default: http://localhost:8002)
+- `MOONDREAM_SERVICE_URL` - Moondream endpoint (default: http://localhost:8003)
 
 ### GPU Node Scheduling
 Services automatically schedule on GPU nodes using node selectors:

--- a/k8s-manifests/moondream-deployment.yaml
+++ b/k8s-manifests/moondream-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moondream-service
+  labels:
+    app: moondream-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: moondream-service
+  template:
+    metadata:
+      labels:
+        app: moondream-service
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      nodeSelector:
+        accelerator: "nvidia-tesla-t4"   # update to match your GPU node label
+      containers:
+      - name: moondream-service
+        image: YOUR_REGISTRY/moondream-service:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8000
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+            memory: 16Gi
+            cpu: 2
+          requests:
+            nvidia.com/gpu: 1
+            memory: 16Gi
+            cpu: 1

--- a/k8s-manifests/moondream-service.yaml
+++ b/k8s-manifests/moondream-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moondream-service
+  labels:
+    app: moondream-service
+spec:
+  selector:
+    app: moondream-service
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP

--- a/moondream-service/Dockerfile
+++ b/moondream-service/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglib2.0-0 libgl1 && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir torch==2.7.0 torchvision==0.15.2+cu118 \
+      -f https://download.pytorch.org/whl/cu118/torch_stable.html && \
+    pip install --no-cache-dir transformers==4.52.4 pillow==9.5.0 requests==2.31.0 \
+      "ray[serve]==2.46.0"
+
+COPY app.py /app.py
+
+ENV PORT 8000
+CMD ["python", "/app.py"]

--- a/moondream-service/Dockerfile
+++ b/moondream-service/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 libgl1 && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir torch==2.7.0 torchvision==0.15.2+cu118 \
+RUN pip install --no-cache-dir torch==2.0.1 torchvision==0.15.2+cu118 \
       -f https://download.pytorch.org/whl/cu118/torch_stable.html && \
     pip install --no-cache-dir transformers==4.52.4 pillow==9.5.0 requests==2.31.0 \
       "ray[serve]==2.46.0"

--- a/moondream-service/app.py
+++ b/moondream-service/app.py
@@ -1,0 +1,285 @@
+import os
+import time
+import signal
+import asyncio
+import base64
+import io
+from typing import Dict, Any
+import ray
+from ray import serve
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from PIL import Image
+
+app = FastAPI(title="Moondream Service", description="Vision-language model using Moondream2")
+
+@serve.deployment(
+    ray_actor_options={"num_gpus": 1 if torch.cuda.is_available() else 0}
+)
+@serve.ingress(app)
+class MoondreamService:
+    def __init__(self):
+        self.device_info = self._get_device_info()
+        self.model = self._initialize_model()
+        print(f"Moondream Service initialized with device: {self.device_info}")
+    
+    def _get_device_info(self) -> Dict[str, Any]:
+        device_info = {
+            "cuda_available": torch.cuda.is_available(),
+            "device_count": torch.cuda.device_count() if torch.cuda.is_available() else 0,
+            "device_name": None,
+            "device_type": "cpu"
+        }
+        
+        if torch.cuda.is_available():
+            device_info["device_name"] = torch.cuda.get_device_name(0)
+            device_info["device_type"] = "gpu"
+        
+        return device_info
+    
+    def _initialize_model(self):
+        device_map = {"": "cuda"} if torch.cuda.is_available() else None
+        return AutoModelForCausalLM.from_pretrained(
+            "vikhyatk/moondream2",
+            revision="2025-04-14",
+            trust_remote_code=True,
+            device_map=device_map
+        )
+    
+    def _process_image(self, request_data: Dict[str, Any]) -> Image.Image:
+        image_data = request_data.get("image")
+        image_url = request_data.get("image_url")
+        
+        if not image_data and not image_url:
+            raise ValueError("Provide either 'image' (base64-encoded) or 'image_url' in request JSON.")
+        
+        if image_data:
+            image_bytes = base64.b64decode(image_data)
+            image = Image.open(io.BytesIO(image_bytes))
+        else:
+            import requests
+            response = requests.get(image_url)
+            response.raise_for_status()
+            image = Image.open(io.BytesIO(response.content))
+        
+        if image.mode != 'RGB':
+            image = image.convert('RGB')
+        
+        return image
+    
+    @app.get("/health")
+    async def health_check(self):
+        return {
+            "status": "healthy",
+            "service": "moondream",
+            "device_info": self.device_info
+        }
+    
+    @app.post("/caption")
+    async def caption_image(self, request_data: Dict[str, Any]) -> JSONResponse:
+        start_time = time.time()
+        
+        try:
+            image = self._process_image(request_data)
+            length = request_data.get("length", "normal")
+            
+            inference_start = time.time()
+            result = self.model.caption(image, length=length)
+            inference_time = time.time() - inference_start
+            
+            caption = result["caption"]
+            
+            total_time = time.time() - start_time
+            
+            response = {
+                "caption": caption,
+                "performance": {
+                    "total_time_ms": round(total_time * 1000, 2),
+                    "inference_time_ms": round(inference_time * 1000, 2),
+                    "device_info": self.device_info
+                }
+            }
+            
+            return JSONResponse(content=response)
+            
+        except Exception as e:
+            error_time = time.time() - start_time
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": f"Captioning failed: {str(e)}",
+                    "performance": {
+                        "error_time_ms": round(error_time * 1000, 2),
+                        "device_info": self.device_info
+                    }
+                }
+            )
+    
+    @app.post("/query")
+    async def query_image(self, request_data: Dict[str, Any]) -> JSONResponse:
+        start_time = time.time()
+        
+        try:
+            image = self._process_image(request_data)
+            question = request_data.get("question") or request_data.get("prompt", "")
+            
+            if not question:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "Provide 'question' or 'prompt' in request JSON."}
+                )
+            
+            inference_start = time.time()
+            result = self.model.query(image, question)
+            inference_time = time.time() - inference_start
+            
+            answer = result["answer"]
+            
+            total_time = time.time() - start_time
+            
+            response = {
+                "answer": answer,
+                "performance": {
+                    "total_time_ms": round(total_time * 1000, 2),
+                    "inference_time_ms": round(inference_time * 1000, 2),
+                    "device_info": self.device_info
+                }
+            }
+            
+            return JSONResponse(content=response)
+            
+        except Exception as e:
+            error_time = time.time() - start_time
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": f"Query failed: {str(e)}",
+                    "performance": {
+                        "error_time_ms": round(error_time * 1000, 2),
+                        "device_info": self.device_info
+                    }
+                }
+            )
+    
+    @app.post("/detect")
+    async def detect_objects(self, request_data: Dict[str, Any]) -> JSONResponse:
+        start_time = time.time()
+        
+        try:
+            image = self._process_image(request_data)
+            object_name = request_data.get("object", "")
+            
+            if not object_name:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "Provide 'object' name in request JSON."}
+                )
+            
+            inference_start = time.time()
+            result = self.model.detect(image, object_name)
+            inference_time = time.time() - inference_start
+            
+            objects = result["objects"]
+            
+            total_time = time.time() - start_time
+            
+            response = {
+                "objects": objects,
+                "count": len(objects),
+                "performance": {
+                    "total_time_ms": round(total_time * 1000, 2),
+                    "inference_time_ms": round(inference_time * 1000, 2),
+                    "device_info": self.device_info
+                }
+            }
+            
+            return JSONResponse(content=response)
+            
+        except Exception as e:
+            error_time = time.time() - start_time
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": f"Detection failed: {str(e)}",
+                    "performance": {
+                        "error_time_ms": round(error_time * 1000, 2),
+                        "device_info": self.device_info
+                    }
+                }
+            )
+    
+    @app.post("/point")
+    async def point_objects(self, request_data: Dict[str, Any]) -> JSONResponse:
+        start_time = time.time()
+        
+        try:
+            image = self._process_image(request_data)
+            object_name = request_data.get("object", "")
+            
+            if not object_name:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "Provide 'object' name in request JSON."}
+                )
+            
+            inference_start = time.time()
+            result = self.model.point(image, object_name)
+            inference_time = time.time() - inference_start
+            
+            points = result["points"]
+            
+            total_time = time.time() - start_time
+            
+            response = {
+                "points": points,
+                "count": len(points),
+                "performance": {
+                    "total_time_ms": round(total_time * 1000, 2),
+                    "inference_time_ms": round(inference_time * 1000, 2),
+                    "device_info": self.device_info
+                }
+            }
+            
+            return JSONResponse(content=response)
+            
+        except Exception as e:
+            error_time = time.time() - start_time
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": f"Pointing failed: {str(e)}",
+                    "performance": {
+                        "error_time_ms": round(error_time * 1000, 2),
+                        "device_info": self.device_info
+                    }
+                }
+            )
+
+def signal_handler(sig, frame):
+    serve.shutdown()
+    ray.shutdown()
+    exit(0)
+
+moondream_service = MoondreamService.bind()
+
+if __name__ == "__main__":
+    import signal
+    import time
+    
+    ray.init()
+    serve.start(http_options={"host": "0.0.0.0", "port": int(os.environ.get("PORT", 8000))})
+    
+    serve.run(moondream_service)
+    
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    
+    print(f"Moondream service is running on port {os.environ.get('PORT', 8000)}")
+    
+    try:
+        while True:
+            time.sleep(60)
+    except KeyboardInterrupt:
+        signal_handler(None, None)

--- a/moondream-service/requirements.txt
+++ b/moondream-service/requirements.txt
@@ -1,6 +1,6 @@
 # Moondream Service specific dependencies
 ray[serve]==2.46.0
-torch==2.7.0
+torch==2.0.1
 transformers==4.52.4
 Pillow>=9.0.0
 requests>=2.28.0

--- a/moondream-service/requirements.txt
+++ b/moondream-service/requirements.txt
@@ -1,0 +1,9 @@
+# Moondream Service specific dependencies
+ray[serve]==2.46.0
+torch==2.7.0
+transformers==4.52.4
+Pillow>=9.0.0
+requests>=2.28.0
+fastapi>=0.100.0
+uvicorn>=0.20.0
+python-multipart>=0.0.6

--- a/moondream-service/tests/test_local.sh
+++ b/moondream-service/tests/test_local.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+echo "Starting Moondream Service local tests..."
+echo "========================================"
+
+SERVICE_URL="http://localhost:8000"
+TIMEOUT=30
+
+wait_for_service() {
+    local url=$1
+    local timeout=$2
+    local count=0
+    
+    echo "Waiting for service at $url to be ready..."
+    
+    while [ $count -lt $timeout ]; do
+        if curl -s "$url/health" > /dev/null 2>&1; then
+            echo "Service is ready!"
+            return 0
+        fi
+        sleep 1
+        count=$((count + 1))
+    done
+    
+    echo "Service failed to start within $timeout seconds"
+    return 1
+}
+
+if ! wait_for_service $SERVICE_URL $TIMEOUT; then
+    echo "Error: Moondream service is not running at $SERVICE_URL"
+    echo "Please start the service first with: python moondream-service/app.py"
+    exit 1
+fi
+
+echo ""
+echo "Running Moondream validation tests..."
+pytest moondream-service/tests/test_moondream_service.py::TestMoondreamService::test_moondream_performance_benchmark -v
+pytest moondream-service/tests/test_moondream_service.py::TestMoondreamService::test_cat_vs_dog_recognition -v
+pytest moondream-service/tests/test_moondream_service.py::TestMoondreamService::test_inside_vs_outside_classification -v
+pytest moondream-service/tests/test_moondream_service.py::TestMoondreamService::test_outdoor_scene_classification -v
+
+echo ""
+echo "All Moondream tests completed successfully!"

--- a/moondream-service/tests/test_moondream_service.py
+++ b/moondream-service/tests/test_moondream_service.py
@@ -1,0 +1,303 @@
+import pytest
+import requests
+import json
+import time
+import base64
+import io
+import os
+from typing import Dict, Any, Callable
+from PIL import Image
+
+class TestMoondreamService:
+    """Test suite for Moondream2 VLM (Vision-Language Model) service."""
+    
+    @pytest.fixture(scope="class")
+    def service_url(self) -> str:
+        """Base URL for the Moondream service."""
+        return "http://localhost:8000"
+    
+    @pytest.fixture(scope="class")
+    def sample_image_url(self) -> str:
+        """Sample image URL for testing."""
+        return "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
+    
+    @pytest.fixture(scope="class")
+    def sample_image_base64(self) -> str:
+        """Sample base64-encoded image for testing."""
+        img = Image.new('RGB', (100, 100), color='red')
+        buffer = io.BytesIO()
+        img.save(buffer, format='PNG')
+        img_bytes = buffer.getvalue()
+        return base64.b64encode(img_bytes).decode('utf-8')
+    
+    @pytest.fixture(scope="class")
+    def cat_image_path(self) -> str:
+        """Path to local cat sample image."""
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(os.path.dirname(script_dir))
+        return os.path.join(project_root, "sample_data", "cats_on_desk", "cat_on_desk_01.png")
+    
+    @pytest.fixture(scope="class")
+    def dog_image_path(self) -> str:
+        """Path to local dog sample image."""
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        project_root = os.path.dirname(os.path.dirname(script_dir))
+        return os.path.join(project_root, "sample_data", "dogs_running", "dog_running_05.png")
+    
+    @pytest.fixture(scope="class")
+    def cat_vs_dog_prompts(self) -> list:
+        """Prompts for cat vs dog classification test."""
+        return ["Is this a cat or a dog?", "What animal is this?"]
+    
+    @pytest.fixture(scope="class")
+    def inside_vs_outside_prompts(self) -> list:
+        """Prompts for inside vs outside classification test."""
+        return ["Is this an indoor or outdoor scene?", "Where is this photo taken - inside or outside?"]
+    
+    @pytest.fixture(scope="class")
+    def image_to_base64(self) -> Callable[[str], str]:
+        """Helper function to convert image files to base64."""
+        def convert(image_path: str) -> str:
+            with open(image_path, 'rb') as f:
+                image_bytes = f.read()
+            return base64.b64encode(image_bytes).decode('utf-8')
+        return convert
+    
+    def test_service_health(self, service_url: str):
+        """Test that the service is running and responsive."""
+        try:
+            response = requests.get(f"{service_url}/health", timeout=10)
+            assert response.status_code == 200
+            result = response.json()
+            assert "status" in result
+            assert result["status"] == "healthy"
+            assert "service" in result
+            assert result["service"] == "moondream"
+            assert "device_info" in result
+        except requests.exceptions.ConnectionError as e:
+            pytest.fail(f"Moondream service is not accessible at {service_url}: {str(e)}")
+    
+    def test_moondream_caption(self, service_url: str, sample_image_url: str):
+        """Test Moondream captioning functionality."""
+        payload = {
+            "image_url": sample_image_url,
+            "length": "normal"
+        }
+        
+        response = requests.post(f"{service_url}/caption", json=payload, timeout=60)
+        assert response.status_code == 200
+        
+        result = response.json()
+        assert "caption" in result
+        assert "performance" in result
+        assert isinstance(result["caption"], str)
+        assert len(result["caption"]) > 0
+        
+        performance = result["performance"]
+        assert "total_time_ms" in performance
+        assert "inference_time_ms" in performance
+        assert "device_info" in performance
+    
+    def test_moondream_query(self, service_url: str, sample_image_url: str):
+        """Test Moondream visual querying functionality."""
+        payload = {
+            "image_url": sample_image_url,
+            "question": "What do you see in this image?"
+        }
+        
+        response = requests.post(f"{service_url}/query", json=payload, timeout=60)
+        assert response.status_code == 200
+        
+        result = response.json()
+        assert "answer" in result
+        assert "performance" in result
+        assert isinstance(result["answer"], str)
+        assert len(result["answer"]) > 0
+    
+    def test_moondream_detect(self, service_url: str, sample_image_url: str):
+        """Test Moondream object detection functionality."""
+        payload = {
+            "image_url": sample_image_url,
+            "object": "food"
+        }
+        
+        response = requests.post(f"{service_url}/detect", json=payload, timeout=60)
+        assert response.status_code == 200
+        
+        result = response.json()
+        assert "objects" in result
+        assert "count" in result
+        assert "performance" in result
+        assert isinstance(result["objects"], list)
+        assert isinstance(result["count"], int)
+    
+    def test_moondream_point(self, service_url: str, sample_image_url: str):
+        """Test Moondream pointing functionality."""
+        payload = {
+            "image_url": sample_image_url,
+            "object": "food"
+        }
+        
+        response = requests.post(f"{service_url}/point", json=payload, timeout=60)
+        assert response.status_code == 200
+        
+        result = response.json()
+        assert "points" in result
+        assert "count" in result
+        assert "performance" in result
+        assert isinstance(result["points"], list)
+        assert isinstance(result["count"], int)
+    
+    def test_moondream_base64_image(self, service_url: str, sample_image_base64: str):
+        """Test Moondream with base64-encoded image."""
+        payload = {
+            "image": sample_image_base64,
+            "question": "Describe what you see in this image."
+        }
+        
+        response = requests.post(f"{service_url}/query", json=payload, timeout=60)
+        assert response.status_code == 200
+        
+        result = response.json()
+        assert "answer" in result
+        assert "performance" in result
+        assert isinstance(result["answer"], str)
+        assert len(result["answer"]) > 0
+        
+        performance = result["performance"]
+        assert "total_time_ms" in performance
+        assert "inference_time_ms" in performance
+        assert "device_info" in performance
+    
+    def test_moondream_missing_image_data(self, service_url: str):
+        """Test Moondream with missing image data."""
+        payload = {
+            "question": "Describe the image."
+        }
+        
+        response = requests.post(f"{service_url}/query", json=payload, timeout=10)
+        result = response.json()
+        
+        assert "error" in result
+        assert "image" in result["error"] or "image_url" in result["error"]
+    
+    def test_moondream_performance_benchmark(self, service_url: str, sample_image_url: str):
+        """Benchmark the performance of Moondream."""
+        payload = {
+            "image_url": sample_image_url,
+            "question": "Describe this image briefly."
+        }
+        
+        requests.post(f"{service_url}/query", json=payload, timeout=60)
+        
+        response_times = []
+        for _ in range(3):
+            start_time = time.time()
+            response = requests.post(f"{service_url}/query", json=payload, timeout=60)
+            end_time = time.time()
+            
+            assert response.status_code == 200
+            response_times.append(end_time - start_time)
+        
+        avg_response_time = sum(response_times) / len(response_times)
+        print(f"Average response time: {avg_response_time:.2f} seconds")
+        
+        assert avg_response_time < 30.0
+    
+    def test_cat_vs_dog_recognition(self, service_url: str, cat_image_path: str, dog_image_path: str, cat_vs_dog_prompts: list, image_to_base64: Callable[[str], str]):
+        """Test that Moondream correctly identifies cat images as cats rather than dogs using local sample images."""
+        assert os.path.exists(cat_image_path), f"Cat sample image not found at {cat_image_path}"
+        assert os.path.exists(dog_image_path), f"Dog sample image not found at {dog_image_path}"
+        
+        cat_base64 = image_to_base64(cat_image_path)
+        cat_payload = {
+            "image": cat_base64,
+            "question": cat_vs_dog_prompts[0]
+        }
+        
+        try:
+            cat_response = requests.post(f"{service_url}/query", json=cat_payload, timeout=60)
+            assert cat_response.status_code == 200
+            cat_result = cat_response.json()
+            assert "answer" in cat_result
+            
+            cat_answer = cat_result["answer"].lower()
+            assert "cat" in cat_answer, f"Cat image should be identified as cat, got: {cat_result['answer']}"
+            
+            dog_base64 = image_to_base64(dog_image_path)
+            dog_payload = {
+                "image": dog_base64,
+                "question": cat_vs_dog_prompts[0]
+            }
+            
+            dog_response = requests.post(f"{service_url}/query", json=dog_payload, timeout=60)
+            assert dog_response.status_code == 200
+            dog_result = dog_response.json()
+            assert "answer" in dog_result
+            
+            dog_answer = dog_result["answer"].lower()
+            assert "dog" in dog_answer, f"Dog image should be identified as dog, got: {dog_result['answer']}"
+            
+            print(f"Cat vs Dog test passed:")
+            print(f"  Cat image response: {cat_result['answer']}")
+            print(f"  Dog image response: {dog_result['answer']}")
+            
+            if "performance" in cat_result:
+                performance = cat_result["performance"]
+                print(f"Performance: {performance.get('total_time_ms', 'N/A')}ms total")
+                print(f"Device: {performance.get('device_info', {}).get('device_type', 'unknown')}")
+            
+        except requests.exceptions.ConnectionError as e:
+            pytest.fail(f"Moondream service is not accessible at {service_url}: {str(e)}")
+    
+    def test_inside_vs_outside_classification(self, service_url: str, cat_image_path: str, inside_vs_outside_prompts: list, image_to_base64: Callable[[str], str]):
+        """Test that Moondream correctly identifies cat desk images as inside rather than outside."""
+        assert os.path.exists(cat_image_path), f"Cat sample image not found at {cat_image_path}"
+        
+        cat_base64 = image_to_base64(cat_image_path)
+        payload = {
+            "image": cat_base64,
+            "question": inside_vs_outside_prompts[0]
+        }
+        
+        try:
+            response = requests.post(f"{service_url}/query", json=payload, timeout=60)
+            assert response.status_code == 200
+            
+            result = response.json()
+            assert "answer" in result
+            assert "performance" in result
+            
+            answer = result["answer"].lower()
+            assert "indoor" in answer or "inside" in answer, f"Cat on desk should be identified as indoor/inside, got: {result['answer']}"
+            
+            print(f"Indoor vs Outdoor classification: {result['answer']}")
+            
+        except requests.exceptions.ConnectionError as e:
+            pytest.fail(f"Moondream service is not accessible at {service_url}: {str(e)}")
+    
+    def test_outdoor_scene_classification(self, service_url: str, dog_image_path: str, inside_vs_outside_prompts: list, image_to_base64: Callable[[str], str]):
+        """Test that Moondream correctly identifies dog running images as outside rather than inside."""
+        assert os.path.exists(dog_image_path), f"Dog sample image not found at {dog_image_path}"
+        
+        dog_base64 = image_to_base64(dog_image_path)
+        payload = {
+            "image": dog_base64,
+            "question": inside_vs_outside_prompts[0]
+        }
+        
+        try:
+            response = requests.post(f"{service_url}/query", json=payload, timeout=60)
+            assert response.status_code == 200
+            
+            result = response.json()
+            assert "answer" in result
+            assert "performance" in result
+            
+            answer = result["answer"].lower()
+            assert "outdoor" in answer or "outside" in answer, f"Dog running in field should be identified as outdoor/outside, got: {result['answer']}"
+            
+            print(f"Outdoor scene classification: {result['answer']}")
+            
+        except requests.exceptions.ConnectionError as e:
+            pytest.fail(f"Moondream service is not accessible at {service_url}: {str(e)}")

--- a/scripts/deploy_ray_service.sh
+++ b/scripts/deploy_ray_service.sh
@@ -98,10 +98,10 @@ if [[ -z "$SERVICE_NAME" ]]; then
 fi
 
 case "$SERVICE_NAME" in
-    clip|gemma|grounding-dino)
+    clip|gemma|grounding-dino|moondream)
         ;;
     *)
-        echo "Error: Invalid service name '$SERVICE_NAME'. Must be one of: clip, gemma, grounding-dino"
+        echo "Error: Invalid service name '$SERVICE_NAME'. Must be one of: clip, gemma, grounding-dino, moondream"
         exit 1
         ;;
 esac

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,13 +71,19 @@ def grounding_dino_service_url() -> str:
     return os.environ.get("GROUNDING_DINO_SERVICE_URL", "http://localhost:8002")
 
 @pytest.fixture(scope="session")
+def moondream_service_url() -> str:
+    """URL for the Moondream service."""
+    return os.environ.get("MOONDREAM_SERVICE_URL", "http://localhost:8003")
+
+@pytest.fixture(scope="session")
 def all_services_running(clip_service_url: str, gemma_service_url: str, 
-                        grounding_dino_service_url: str, service_timeout: int) -> bool:
+                        grounding_dino_service_url: str, moondream_service_url: str, service_timeout: int) -> bool:
     """Check if all services are running and accessible."""
     services = {
         "CLIP": clip_service_url,
         "Gemma": gemma_service_url,
-        "Grounding DINO": grounding_dino_service_url
+        "Grounding DINO": grounding_dino_service_url,
+        "Moondream": moondream_service_url
     }
     
     running_services = []


### PR DESCRIPTION
# Add MoondreamService with Comprehensive Vision-Language Capabilities

## Overview
This PR implements a new MoondreamService following the established patterns in the Ray Serve Inference Menagerie, providing comprehensive vision-language model capabilities using Moondream2.

## Features Implemented

### 🌙 MoondreamService
- **Model**: `vikhyatk/moondream2` with revision `2025-04-14`
- **GPU Support**: Ray Serve deployment with automatic GPU allocation
- **Multiple Endpoints**:
  - `POST /caption` - Generate image captions (short/normal length)
  - `POST /query` - Answer questions about images
  - `POST /detect` - Detect specific objects in images
  - `POST /point` - Point to object locations in images
  - `GET /health` - Health check endpoint

### 🧪 Comprehensive Testing
- Cat vs dog classification tests using sample data
- Inside vs outside scene classification tests
- Performance benchmarking
- All four endpoint functionality tests
- Error handling and edge case validation
- Base64 and URL image input support

### 🚀 Deployment Infrastructure
- Kubernetes manifests (`moondream-deployment.yaml`, `moondream-service.yaml`)
- Updated deployment script to support `moondream` service
- Docker containerization with GPU support
- Resource allocation (16Gi memory, 1 GPU, 2 CPU)

## Files Added/Modified

### New Files
- `moondream-service/app.py` - Main service implementation
- `moondream-service/requirements.txt` - Dependencies
- `moondream-service/Dockerfile` - Container configuration
- `moondream-service/tests/test_moondream_service.py` - Comprehensive test suite
- `moondream-service/tests/test_local.sh` - Local testing script
- `k8s-manifests/moondream-deployment.yaml` - Kubernetes deployment
- `k8s-manifests/moondream-service.yaml` - Kubernetes service

### Modified Files
- `scripts/deploy_ray_service.sh` - Added moondream to supported services
- `README.md` - Added documentation and examples
- `tests/conftest.py` - Added moondream service URL fixture

## Testing Strategy

The service includes comprehensive tests following the exact patterns from existing services:

```bash
# Test cat vs dog classification
pytest moondream-service/tests/test_moondream_service.py::TestMoondreamService::test_cat_vs_dog_recognition -v

# Test inside vs outside classification  
pytest moondream-service/tests/test_moondream_service.py::TestMoondreamService::test_inside_vs_outside_classification -v

# Run all tests
pytest moondream-service/tests/test_moondream_service.py -v
```

## Usage Examples

```bash
# Caption generation
curl -X POST -H "Content-Type: application/json" \
    -d '{"image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png",
         "length": "normal"}' \
    http://localhost:8003/caption

# Visual querying
curl -X POST -H "Content-Type: application/json" \
    -d '{"image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png",
         "question": "What food is shown in this image?"}' \
    http://localhost:8003/query

# Object detection
curl -X POST -H "Content-Type: application/json" \
    -d '{"image_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png",
         "object": "food"}' \
    http://localhost:8003/detect
```

## Deployment

```bash
# Deploy to Kubernetes
./scripts/deploy_ray_service.sh moondream --username charlie --node-selector gpu=true

# Port forward for local access
kubectl port-forward svc/charlie-moondream-service 8083:80
```

## Architecture Consistency

This implementation follows the exact same patterns as existing services:
- ✅ Ray Serve deployment with GPU allocation
- ✅ FastAPI with proper error handling and JSON responses
- ✅ Performance monitoring with timing metrics
- ✅ Device info reporting for debugging
- ✅ Base64 and URL image input support
- ✅ Health check endpoint
- ✅ Comprehensive test coverage
- ✅ Kubernetes deployment manifests
- ✅ Docker containerization

## Link to Devin run
https://app.devin.ai/sessions/1a1fb6ea093f445f9e2f96dc3ffc77e3

## Requested by
lsb (leebutterman@gmail.com)
